### PR TITLE
Enable the GitHub Wiki for documentation

### DIFF
--- a/otterdog/eclipse-swtimagej.jsonnet
+++ b/otterdog/eclipse-swtimagej.jsonnet
@@ -12,6 +12,7 @@ orgs.newOrg('technology.swtimagej', 'eclipse-swtimagej') {
   _repositories+:: [
     orgs.newRepo('SWTImageJ') {
       default_branch: "develop",
+      has_wiki: true,
     },
     orgs.newRepo('website') {
       allow_merge_commit: true,


### PR DESCRIPTION
because this causes rebuilds even without code changes:
![grafik](https://github.com/user-attachments/assets/9b33db16-1e7d-4af0-9dd6-b2f47f46964e)
so trim it down and document at the wiki instead.